### PR TITLE
Resilient Reddit fetcher (retries/backoff) + optional thread pool (~50% faster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@ AGENTS.md
 /z_archive/
 /data/
 
+.DS_Store
 
 # Ignore .cursorignore
 .cursorignore
+.cursor
 
 # Ignore logs and temp files
 *.log

--- a/config/settings.py
+++ b/config/settings.py
@@ -51,6 +51,10 @@ class Settings(BaseSettings):
     MAX_SUBREDDITS: int = 3
     MAX_SEARCH_TERMS: int = 5
 
+    #Multithreading Configuration
+    FETCHER_MAX_WORKERS: int = 3
+    FETCHER_ENABLE_CONCURRENCY: bool = False
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/config/settings.py
+++ b/config/settings.py
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
 
     #Multithreading Configuration
     FETCHER_MAX_WORKERS: int = 3
-    FETCHER_ENABLE_CONCURRENCY: bool = False
+    FETCHER_ENABLE_CONCURRENCY: bool = True
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/docs/concurrency_plan.md
+++ b/docs/concurrency_plan.md
@@ -1,0 +1,36 @@
+## Minimal Multithreading Plan for the Reddit Fetcher
+
+Goal: add a small, optional thread pool to run multiple `(subreddit, term)` fetches in parallel, plus a timing log to measure before/after. Keep it easy to turn off and easy to revert.
+
+### Terminology
+- We’ll call this **multithreading** (a thread pool with a few worker threads). It’s the simplest way to add concurrency without rewriting code to async/await.
+
+### Step-by-Step
+1) **Config knobs**  
+   - Add `FETCHER_MAX_WORKERS` (start with 2–3).  
+   - Add `FETCHER_ENABLE_CONCURRENCY` (default False so current behavior stays as-is).  
+   - These live in `config/settings.py` and let us toggle the pool on/off without code edits.
+
+2) **Timing log in the preview script**  
+   - In `scripts/run_fetch_preview.py`, record `start = time.perf_counter()` before `run_reddit_fetcher(...)` and `end = time.perf_counter()` after.  
+   - Log/print the elapsed seconds and the count of subreddits × terms. This gives a clean before/after number without relying on `/usr/bin/time`.
+
+3) **Helper for one task**  
+   - In `services/fetch/reddit_fetcher.py`, add a helper that processes one `(subreddit, term, post_limit, fetched_at)` and returns `list[Post]`.  
+   - Inside the helper: create a fresh `RedditClient`, run the existing per-post logic (validation, scoring, fetch comments, build models), and return the accepted posts. Do not share `seen_post_ids` here.
+
+4) **Thread pool wiring**  
+   - In `run_reddit_fetcher`, build all `(subreddit, term)` tasks.  
+   - If concurrency is disabled, run tasks serially (current behavior).  
+   - If enabled, create `ThreadPoolExecutor(max_workers=settings.FETCHER_MAX_WORKERS)`, submit one task per pair, and gather futures with `as_completed`.  
+   - Maintain a single `seen_post_ids` in the main thread; as each future returns `list[Post]`, skip any post whose ID is already seen, otherwise add it to the master `accepted_posts`.
+
+5) **API stability / rollback**  
+   - Keep `run_reddit_fetcher`’s signature the same; callers don’t change.  
+   - Because it’s driven by config, turning concurrency off is just flipping the toggle. No risky rollback needed.
+
+6) **Measure and decide**  
+   - Run `scripts/run_fetch_preview.py` with concurrency off to capture baseline (timing log).  
+   - Turn concurrency on (small worker count) and rerun the same queries; compare elapsed time.  
+   - If gains are minimal, set the toggle back to False and you’re back to serial.
+

--- a/docs/concurrency_results.md
+++ b/docs/concurrency_results.md
@@ -1,0 +1,19 @@
+## Reddit Fetcher Concurrency Results
+
+- **Queries:** Default preview list (10 queries) for all measurements.
+- **Command:** `python -m scripts.run_fetch_preview --post-limit 10` (same options each time).
+- **Artifacts:** Preview JSONs saved under `data/fetch_previews/` for each timing run.
+- **Observability:** No warnings about `RateLimitError` or `RetryableFetchError` appeared in any run (logs stayed at INFO level only).
+
+### Timing Summary
+| Run Mode                | `FETCHER_ENABLE_CONCURRENCY` | `FETCHER_MAX_WORKERS` | Total Time (10 queries) | Preview Artifact                                                  |
+| ----------------------- | ---------------------------- | --------------------- | ----------------------- | ----------------------------------------------------------------- |
+| Serial Baseline         | False                        | n/a                   | ~102 s                  | `data/fetch_previews/fetch_preview_20251120_serial_baseline.json` |
+| Threaded (Conservative) | True                         | 2                     | ~76.5 s                 | `data/fetch_previews/fetch_preview_20251120_threaded2.json`       |
+| Threaded (Current)      | True                         | 3                     | ~54.4 s                 | `data/fetch_previews/fetch_preview_20251120_threaded3.json`       |
+
+### Notes
+- Multithreading yielded a ~25% speedup with 2 workers and ~47% with 3 workers compared to the serial baseline.
+- No rate-limit hits or post-fetch retries were observed in any run.
+- All runs used the same 10 queries; order differences in output are expected due to concurrency.
+- Logs aren’t persisted, so timings are inferred from the new INFO-level duration logs added to `scripts/run_fetch_preview.py`.

--- a/docs/refactor-fetcher-plan.md
+++ b/docs/refactor-fetcher-plan.md
@@ -33,22 +33,22 @@ Focused 4-day plan (≈8 hours/day) to stabilize the fetcher, add resilience, an
 **Helper Inventory (Current → Target)**  
 _Functions currently implemented inside `services/fetch/reddit_fetcher.py`._
 
-| Function / Helper         | Function Signature                                                       | Purpose                                       | Target Module        |
-|--------------------------|---------------------------------------------------------------------------|-----------------------------------------------|----------------------|
-| `_get_client`            | `def _get_client(environment: str = "dev") -> Session`                    | Build authenticated `requests.Session`        | `reddit_client.py`   |
-| `search_subreddit`       | `def search_subreddit(subreddit: str, query: str, limit: int = 25, after: str \| None = None, environment: str = "dev") -> dict` | Call Reddit search endpoint | `reddit_client.py` |
-| `paginate_search`        | `def paginate_search(subreddit: str, query: str, limit: int, environment: str = "dev") -> Iterator[dict]` | Iterate through search pages | `reddit_client.py` |
-| `fetch_comments`         | `def fetch_comments(post_id: str, limit: int = 50, environment: str = "dev") -> list[dict]` | Fetch top-level comments for a submission | `reddit_client.py` |
-| `passes_post_validation` | `def passes_post_validation(raw_post: dict[str, Any]) -> bool`            | Run metadata veto checks                      | `reddit_validation.py` |
-| `is_post_too_short`      | `def is_post_too_short(body: str) -> bool`                                | Enforce minimum body length                   | `reddit_validation.py` |
-| `has_seen_post`          | `def has_seen_post(post_id: str, seen_post_ids: set[str]) -> bool`        | Deduplicate posts per run                     | `reddit_validation.py` |
-| `filter_comments`        | `def filter_comments(post_id: str, raw_comments: list[dict[str, Any]]) -> list[dict[str, Any]]` | Apply comment-level vetoes | `reddit_validation.py` |
-| `is_comment_too_short`   | `def is_comment_too_short(body: str) -> bool`                             | Enforce minimum comment length                | `reddit_validation.py` |
-| `has_seen_comment`       | `def has_seen_comment(comment_id: str, seen_comment_ids: set[str]) -> bool` | Deduplicate comments per run                | `reddit_validation.py` |
-| `_build_comment_payload` | `def _build_comment_payload(*, comment_id: str, post_id: str, cleaned_body: str, comment_karma: int) -> dict[str, Any]` | Normalize filtered comment data | `reddit_assembly.py` |
-| `build_comment_models`   | `def build_comment_models(filtered_comments: list[dict[str, Any]], fetched_at: float) -> list[Comment]` | Convert payloads into `Comment` objects | `reddit_assembly.py` |
-| `build_post_model`       | `def build_post_model(*, raw_post: dict[str, Any], cleaned_title: str, cleaned_body: str, relevance_score: float, matched_keywords: list[str], comments: list[Comment], fetched_at: float) -> Post` | Construct `Post` objects from cleaned data | `reddit_assembly.py` |
-| `post_permalink`         | `def post_permalink(raw_post: dict[str, Any]) -> str`                     | Produce canonical Reddit URL for a submission | `reddit_assembly.py` |
+| Function / Helper        | Function Signature                                                                                                                                                                                  | Purpose                                       | Target Module          |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------- |
+| `_get_client`            | `def _get_client(environment: str = "dev") -> Session`                                                                                                                                              | Build authenticated `requests.Session`        | `reddit_client.py`     |
+| `search_subreddit`       | `def search_subreddit(subreddit: str, query: str, limit: int = 25, after: str \| None = None, environment: str = "dev") -> dict`                                                                    | Call Reddit search endpoint                   | `reddit_client.py`     |
+| `paginate_search`        | `def paginate_search(subreddit: str, query: str, limit: int, environment: str = "dev") -> Iterator[dict]`                                                                                           | Iterate through search pages                  | `reddit_client.py`     |
+| `fetch_comments`         | `def fetch_comments(post_id: str, limit: int = 50, environment: str = "dev") -> list[dict]`                                                                                                         | Fetch top-level comments for a submission     | `reddit_client.py`     |
+| `passes_post_validation` | `def passes_post_validation(raw_post: dict[str, Any]) -> bool`                                                                                                                                      | Run metadata veto checks                      | `reddit_validation.py` |
+| `is_post_too_short`      | `def is_post_too_short(body: str) -> bool`                                                                                                                                                          | Enforce minimum body length                   | `reddit_validation.py` |
+| `has_seen_post`          | `def has_seen_post(post_id: str, seen_post_ids: set[str]) -> bool`                                                                                                                                  | Deduplicate posts per run                     | `reddit_validation.py` |
+| `filter_comments`        | `def filter_comments(post_id: str, raw_comments: list[dict[str, Any]]) -> list[dict[str, Any]]`                                                                                                     | Apply comment-level vetoes                    | `reddit_validation.py` |
+| `is_comment_too_short`   | `def is_comment_too_short(body: str) -> bool`                                                                                                                                                       | Enforce minimum comment length                | `reddit_validation.py` |
+| `has_seen_comment`       | `def has_seen_comment(comment_id: str, seen_comment_ids: set[str]) -> bool`                                                                                                                         | Deduplicate comments per run                  | `reddit_validation.py` |
+| `_build_comment_payload` | `def _build_comment_payload(*, comment_id: str, post_id: str, cleaned_body: str, comment_karma: int) -> dict[str, Any]`                                                                             | Normalize filtered comment data               | `reddit_assembly.py`   |
+| `build_comment_models`   | `def build_comment_models(filtered_comments: list[dict[str, Any]], fetched_at: float) -> list[Comment]`                                                                                             | Convert payloads into `Comment` objects       | `reddit_assembly.py`   |
+| `build_post_model`       | `def build_post_model(*, raw_post: dict[str, Any], cleaned_title: str, cleaned_body: str, relevance_score: float, matched_keywords: list[str], comments: list[Comment], fetched_at: float) -> Post` | Construct `Post` objects from cleaned data    | `reddit_assembly.py`   |
+| `post_permalink`         | `def post_permalink(raw_post: dict[str, Any]) -> str`                                                                                                                                               | Produce canonical Reddit URL for a submission | `reddit_assembly.py`   |
 
 
 ---
@@ -57,7 +57,7 @@ _Functions currently implemented inside `services/fetch/reddit_fetcher.py`._
 
 **Happy Path (Critical)**
 - Enhance `reddit_client.py` with Tenacity-style retries/backoff and basic rate-limit handling (429 detection, structured exceptions).
-- Ensure all orchestrator calls go through the resilient client and catch `FetchError` / `RateLimitError` without crashing runs.
+- Ensure all orchestrator calls go through the resilient client and catch `RetryableFetchError` / `RateLimitError` without crashing runs.
 - Introduce a small thread pool (or staged hook) so multiple queries can fetch concurrently, but keep pool size conservative to respect rate limits.
 - Re-run preview/eval scripts to verify stability and measure runtime improvement.
 

--- a/scripts/run_fetch_preview.py
+++ b/scripts/run_fetch_preview.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import List
@@ -25,14 +26,14 @@ app = typer.Typer(add_completion=False)
 DEFAULT_QUERIES: List[str] = [
     "how to caulk bathtub",
     "how to repair holes in drywall",
-    #"how to install peel and stick vinyl flooring in an apartment",
-    #"how to touch up chipped wall paint",
-    #"how to mount a TV safely",
-    #"how to hang picture frames straight",
-    #"how to hang floating wall shelves",
-    #"how to build a raised garden bed",
-    #"how to fix a broken light fixture or loose outlet cover",
-    #"how to paint a room properly",
+    "how to install laminate flooring in an apartment",
+    "how to touch up chipped wall paint",
+    "how to mount a TV safely",
+    "how to remove scratches from wood table",
+    "how to hang floating wall shelves",
+    "how to build a raised garden bed",
+    "how to fix a broken light fixture",
+    "how to paint a room properly",
 ]
 
 PREVIEW_DIR = Path("data/fetch_previews")
@@ -116,10 +117,18 @@ def run(
             continue
 
         try:
+            start = time.perf_counter()
             fetch_result = run_reddit_fetcher(
                 plan=plan,
                 post_limit=post_limit,
                 environment=environment,
+            )
+            elapsed = time.perf_counter() - start
+            logger.info(
+                "Fetch done in %.2fs (subreddits=%d, terms=%d)",
+                elapsed,
+                len(plan.subreddits),
+                len(plan.search_terms),
             )
         except Exception as exc:
             logger.error("Fetcher failed for query '%s': %s", query, exc)

--- a/scripts/run_fetch_preview.py
+++ b/scripts/run_fetch_preview.py
@@ -100,6 +100,7 @@ def run(
 
     logger.info("Running fetch preview for %d queries", len(queries))
     preview_payload: list[dict] = []
+    total_start = time.perf_counter()
 
     for query in queries:
         logger.info("Processing query: %s", query)
@@ -160,9 +161,15 @@ def run(
             }
         )
 
+    total_elapsed = time.perf_counter() - total_start
     timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     preview_path = PREVIEW_DIR / f"fetch_preview_{timestamp}.json"
     preview_path.write_text(json.dumps(preview_payload, indent=2), encoding="utf-8")
+    logger.info(
+        "All queries done in %.2fs (count=%d)",
+        total_elapsed,
+        len(queries),
+    )
     logger.info("Fetch preview saved to %s", preview_path)
 
 

--- a/services/fetch/reddit_fetcher.py
+++ b/services/fetch/reddit_fetcher.py
@@ -1,25 +1,126 @@
-from typing import Any
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from agent.planner.model import SearchPlan
-from services.reddit_client import RedditClient
-from services.http.retry_policy import RateLimitError, RetryableFetchError
-from .reddit_validation import passes_post_validation
-from .content_filters import (
-    is_post_too_short,
-    has_seen_post,
-)
-from .comment_pipeline import filter_comments
-from .utils.text_utils import clean_text
-from .utils.datetime_utils import utc_now
-from .scoring import evaluate_post_relevance
-from .schemas import Post, Comment, FetchResult
-from .reddit_builders import (
-    build_comment_models,
-    build_post_model,
-)
 from config.logging_config import get_logger
+from config.settings import settings
+from services.http.retry_policy import RateLimitError, RetryableFetchError
+from services.reddit_client import RedditClient
+
+from .comment_pipeline import filter_comments
+from .content_filters import has_seen_post, is_post_too_short
+from .reddit_builders import build_comment_models, build_post_model
+from .reddit_validation import passes_post_validation
+from .schemas import FetchResult, Post
+from .scoring import evaluate_post_relevance
+from .utils.datetime_utils import utc_now
+from .utils.text_utils import clean_text
 
 logger = get_logger(__name__)
+
+
+def _fetch_posts_for_pair(
+    *,
+    subreddit: str,
+    term: str,
+    post_limit: int,
+    fetched_at: float,
+    client: RedditClient | None = None,
+) -> list[Post]:
+    """Fetch and filter posts for a single (subreddit, term) pair."""
+    accepted: list[Post] = []
+    local_seen_post_ids: set[str] = set()
+    reddit_client = client or RedditClient()
+
+    try:
+        for raw_post in reddit_client.paginate_search(
+            subreddit=subreddit,
+            query=term,
+            limit=post_limit,
+        ):
+            post_id = raw_post.get("id")
+            if not post_id:
+                logger.info(
+                    "Rejecting post without ID (subreddit=%s, term=%s)",
+                    subreddit,
+                    term,
+                )
+                continue
+
+            if not passes_post_validation(raw_post):
+                continue
+
+            title = clean_text(raw_post.get("title", ""))
+            body = clean_text(raw_post.get("selftext", ""))
+
+            score, positives, _, passed = evaluate_post_relevance(
+                post_id=post_id,
+                title=title,
+                body=body,
+            )
+            if not passed:
+                logger.info("Rejecting post %s: below_threshold", post_id)
+                continue
+
+            if is_post_too_short(body):
+                logger.info("Rejecting post %s: too_short", post_id)
+                continue
+
+            if has_seen_post(post_id, local_seen_post_ids):
+                logger.info("Rejecting post %s: duplicate", post_id)
+                continue
+
+            try:
+                raw_comments = reddit_client.fetch_comments(post_id=post_id)
+            except RateLimitError as exc:
+                logger.warning(
+                    "429: Too many requests while fetching comments (post_id=%s): %s",
+                    post_id,
+                    exc,
+                )
+                continue
+            except RetryableFetchError as exc:
+                logger.warning(
+                    "Comments fetch failed after retries (post_id=%s): %s",
+                    post_id,
+                    exc,
+                )
+                continue
+
+            filtered_comments = filter_comments(
+                post_id=post_id,
+                raw_comments=raw_comments,
+            )
+
+            comment_models = build_comment_models(filtered_comments, fetched_at)
+            if not comment_models:
+                logger.info("Rejecting post %s: no_comments", post_id)
+                continue
+
+            post_model = build_post_model(
+                raw_post=raw_post,
+                cleaned_title=title,
+                cleaned_body=body,
+                relevance_score=score,
+                matched_keywords=positives,
+                comments=comment_models,
+                fetched_at=fetched_at,
+            )
+            accepted.append(post_model)
+    except RateLimitError as exc:
+        logger.warning(
+            "429: Too many requests while searching (subreddit=%s, term=%s): %s",
+            subreddit,
+            term,
+            exc,
+        )
+    except RetryableFetchError as exc:
+        logger.warning(
+            "Search failed after retries (subreddit=%s, term=%s): %s",
+            subreddit,
+            term,
+            exc,
+        )
+    return accepted
 
 
 def run_reddit_fetcher(
@@ -32,104 +133,61 @@ def run_reddit_fetcher(
     Orchestrate the Reddit fetch pipeline for a planner-produced SearchPlan.
     """
     fetched_at = utc_now()
-    seen_post_ids: set[str] = set()
     accepted_posts: list[Post] = []
+    seen_post_ids: set[str] = set()
     plan_query = plan.query
-    client = RedditClient()
 
-    for subreddit in plan.subreddits:
-        for term in plan.search_terms:
-            try:
-                for raw_post in client.paginate_search(
+    tasks = [
+        (subreddit, term)
+        for subreddit in plan.subreddits
+        for term in plan.search_terms
+    ]
+
+    def _merge_posts(posts: list[Post]) -> None:
+        for post in posts:
+            post_id = getattr(post, "id", None)
+            if not post_id or post_id in seen_post_ids:
+                continue
+            seen_post_ids.add(post_id)
+            accepted_posts.append(post)
+
+    if not settings.FETCHER_ENABLE_CONCURRENCY:
+        client = RedditClient()
+        for subreddit, term in tasks:
+            posts = _fetch_posts_for_pair(
+                client=client,
+                subreddit=subreddit,
+                term=term,
+                post_limit=post_limit,
+                fetched_at=fetched_at,
+            )
+            _merge_posts(posts)
+    else:
+        max_workers = max(1, settings.FETCHER_MAX_WORKERS)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_map = {
+                executor.submit(
+                    _fetch_posts_for_pair,
                     subreddit=subreddit,
-                    query=term,
-                    limit=post_limit,
-                ):
-                    post_id = raw_post.get("id")
-                    if not post_id:
-                        logger.info(
-                            "Rejecting post without ID (subreddit=%s, term=%s)",
-                            subreddit,
-                            term,
-                        )
-                        continue
-
-                    if not passes_post_validation(raw_post):
-                        continue
-
-                    title = clean_text(raw_post.get("title", ""))
-                    body = clean_text(raw_post.get("selftext", ""))
-
-                    score, positives, _, passed = evaluate_post_relevance(
-                        post_id=post_id,
-                        title=title,
-                        body=body,
+                    term=term,
+                    post_limit=post_limit,
+                    fetched_at=fetched_at,
+                ): (subreddit, term)
+                for subreddit, term in tasks
+            }
+            for future in as_completed(future_map):
+                subreddit, term = future_map[future]
+                try:
+                    posts = future.result()
+                except Exception as exc:
+                    logger.warning(
+                        "Concurrent fetch failed (subreddit=%s, term=%s): %s",
+                        subreddit,
+                        term,
+                        exc,
                     )
-                    if not passed:
-                        logger.info("Rejecting post %s: below_threshold", post_id)
-                        continue
-
-                    if is_post_too_short(body):
-                        logger.info("Rejecting post %s: too_short", post_id)
-                        continue
-
-                    if has_seen_post(post_id, seen_post_ids):
-                        logger.info("Rejecting post %s: duplicate", post_id)
-                        continue
-
-                    try:
-                        raw_comments = client.fetch_comments(post_id=post_id)
-                    except RateLimitError as exc:
-                        logger.warning(
-                            "429: Too many requests while fetching comments (post_id=%s): %s",
-                            post_id,
-                            exc,
-                        )
-                        continue
-                    except RetryableFetchError as exc:
-                        logger.warning(
-                            "Comments fetch failed after retries (post_id=%s): %s",
-                            post_id,
-                            exc,
-                        )
-                        continue
-
-                    filtered_comments = filter_comments(
-                        post_id=post_id,
-                        raw_comments=raw_comments,
-                    )
-
-                    comment_models = build_comment_models(filtered_comments, fetched_at)
-                    if not comment_models:
-                        logger.info("Rejecting post %s: no_comments", post_id)
-                        continue
-
-                    post_model = build_post_model(
-                        raw_post=raw_post,
-                        cleaned_title=title,
-                        cleaned_body=body,
-                        relevance_score=score,
-                        matched_keywords=positives,
-                        comments=comment_models,
-                        fetched_at=fetched_at,
-                    )
-                    accepted_posts.append(post_model)
-            except RateLimitError as exc:
-                logger.warning(
-                    "429: Too many requests while searching (subreddit=%s, term=%s): %s",
-                    subreddit,
-                    term,
-                    exc,
-                )
-                continue
-            except RetryableFetchError as exc:
-                logger.warning(
-                    "Search failed after retries (subreddit=%s, term=%s): %s",
-                    subreddit,
-                    term,
-                    exc,
-                )
-                continue
+                    continue
+                _merge_posts(posts)
 
     return FetchResult(
         query=plan_query,

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -1,0 +1,65 @@
+"""Resilience tests for the Reddit fetch orchestrator."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from agent.planner.model import SearchPlan
+from services.fetch.reddit_fetcher import run_reddit_fetcher
+from services.http.retry_policy import RateLimitError, RetryableFetchError
+
+
+def _make_plan() -> SearchPlan:
+    return SearchPlan(
+        plan_id=uuid4(),
+        query="test query",
+        search_terms=["test term"],
+        subreddits=["diy"],
+        notes="unit test plan",
+    )
+
+
+def test_search_error(mocker):
+    """Search-level RateLimitError/RetryableFetchError should be handled and return an empty result."""
+    plan = _make_plan()
+
+    mock_client = mocker.Mock()
+    mock_client.paginate_search.side_effect = RateLimitError("rate limited")
+
+    mocker.patch("services.fetch.reddit_fetcher.RedditClient", return_value=mock_client)
+
+    result = run_reddit_fetcher(plan=plan, post_limit=5)
+
+    assert result.posts == []
+    assert result.query == plan.query
+
+
+def test_comment_error(mocker):
+    """Comment-level RateLimitError/RetryableFetchError should be handled and skip the post."""
+    plan = _make_plan()
+
+    mock_client = mocker.Mock()
+    mock_client.paginate_search.return_value = iter(
+        [
+            {
+                "id": "abc123",
+                "title": "How to fix something",
+                "selftext": "Body content",
+            }
+        ]
+    )
+    mock_client.fetch_comments.side_effect = RetryableFetchError("temporary failure")
+
+    mocker.patch("services.fetch.reddit_fetcher.RedditClient", return_value=mock_client)
+    mocker.patch("services.fetch.reddit_fetcher.passes_post_validation", return_value=True)
+    mocker.patch("services.fetch.reddit_fetcher.is_post_too_short", return_value=False)
+    mocker.patch("services.fetch.reddit_fetcher.has_seen_post", return_value=False)
+    mocker.patch(
+        "services.fetch.reddit_fetcher.evaluate_post_relevance",
+        return_value=(1.0, ["keyword"], None, True),
+    )
+
+    result = run_reddit_fetcher(plan=plan, post_limit=5)
+
+    assert result.posts == []
+    assert result.query == plan.query


### PR DESCRIPTION
**PR Overview:** 

- Adds orchestrator-level resilience (catching RateLimitError / RetryableFetchError) plus unit tests to ensure fetches keep running if any API issues. 
- Also introduce an optional, configurable thread pool for the Reddit fetcher with per-query and overall timing logs. 
- Benchmarks across the default 10-query preview show ~102 s baseline (serial), ~76 s with 2 workers, and ~54 s with 3 workers (~50% faster), all without triggering rate-limit warnings.

**Changes:** 
1. Catch RateLimitError / RetryableFetchError in the main orchestrator and add unit tests (closes #71)
2. Refresh Day 2 doc plan
3. Add config toggles, baseline timing logs, and concurrency planning notes
4. Introduce the _fetch_posts_for_pair helper plus an optional ThreadPoolExecutor path (with dedupe) and log per-query + total runtimes